### PR TITLE
feat: Prevent redundant bookmark bar loading

### DIFF
--- a/src/background/handlers.ts
+++ b/src/background/handlers.ts
@@ -98,12 +98,10 @@ export const handleShortcut = debounce(async (command: string) => {
     }
 
     if (/^switch-to-[1-9]$/u.test(command)) {
-      const index = Number(command.split('-')[2]) - 1;
-      const title = bars[index] ? bars[index].title : bars[0].title;
-      if (title !== currentBarTitle) {
+        const index = Number(command.split('-')[2]) - 1;
+        const title = bars[index] ? bars[index].title : bars[0].title;
         await exchange(title);
-      }
-      return;
+        return;
     }
 
     let title;

--- a/src/background/handlers.ts
+++ b/src/background/handlers.ts
@@ -98,10 +98,12 @@ export const handleShortcut = debounce(async (command: string) => {
     }
 
     if (/^switch-to-[1-9]$/u.test(command)) {
-        const index = Number(command.split('-')[2]) - 1;
-        const title = bars[index] ? bars[index].title : bars[0].title;
+      const index = Number(command.split('-')[2]) - 1;
+      const title = bars[index] ? bars[index].title : bars[0].title;
+      if (title !== currentBarTitle) {
         await exchange(title);
-        return;
+      }
+      return;
     }
 
     let title;

--- a/src/background/service.ts
+++ b/src/background/service.ts
@@ -35,6 +35,10 @@ export async function exchange(title: string) {
     const [sourceId] = await findFolder(customFolderId, title);
     const [targetId] = await findFolder(customFolderId, currentBarTitle);
 
+    if (sourceId === targetId) {
+      return;
+    }
+
     // move the current bar to target folder
     await moveBookmark(bookmarkBarId, targetId);
     // move the source folder to the main bar


### PR DESCRIPTION
Modified the behavior of switching bookmark bars triggered by a hotkey to avoid redundant loading of the same bookmark bar. Now, when switching to a bookmark bar, the extension checks if the target bar is already active. If it is, the exchange is skipped to prevent triggering the browser's sync service. This change enhances user experience and optimizes browser behavior.

- Added a check to compare the target bookmark bar title with the current active bar title.
- Skips the exchange if the target bar is already active to prevent redundant loading.
