### PR TITLE
ci: Set user to github-actions when bumping version

### DIFF
--- a/.github/workflows/bump-release-publish.yaml
+++ b/.github/workflows/bump-release-publish.yaml
@@ -31,6 +31,9 @@ jobs:
         version-type: ${{ github.event.inputs.version }}
         tag-prefix:  'v'
         commit-message: 'ci: Bump version to {{version}}'
+      env:
+        GITHUB_USER: github-actions[bot]
+        GITHUB_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
     outputs:
       tag: ${{ steps.version_bump.outputs.newTag }}
   release:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

When bumping the application version the GitHub user is not set correctly. Through this change it will now be displayed as `github-actions`.

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have created a feature (non-master) branch for my PR.
