### PR TITLE
fix: Bars getting merged randomly

### DIFF
--- a/src/background/storage.ts
+++ b/src/background/storage.ts
@@ -133,30 +133,30 @@ async function getActiveWorkspaceId() {
 }
 
 /**
- * Get an entry from the synced browser storage.
+ * Get an entry from the local browser storage.
  *
  * @param key - The entry key.
  * @returns The entry.
  */
 async function get<T>(key: string): Promise<T | undefined> {
-    const syncedData: Record<string, T> = await chrome.storage.sync.get(key);
+    const localData: Record<string, T> = await chrome.storage.local.get(key);
 
-    if (Object.keys(syncedData).length === 0 || syncedData[key] === undefined) {
+    if (Object.keys(localData).length === 0 || localData[key] === undefined) {
         return undefined;
     }
-    return syncedData[key];
+    return localData[key];
 }
 
 /**
- * Set an entry in the synced browser storage.
+ * Set an entry in the local browser storage.
  *
  * @param key - The entry key.
  * @param value - The entry value.
  */
 async function set<T>(key: string, value: T) {
-    const data: Record<string, T> = {};
-    data[key] = value;
-    await chrome.storage.sync.set(data);
+    const localData: Record<string, T> = {};
+    localData[key] = value;
+    await chrome.storage.local.set(localData);
 }
 
 async function createDefaultBar() {

--- a/src/background/storage.ts
+++ b/src/background/storage.ts
@@ -133,37 +133,29 @@ async function getActiveWorkspaceId() {
 }
 
 /**
- * Get an entry from the browser storage.
- * The synced storage will only be accessed
- * if the key is not present in the local storage.
+ * Get an entry from the synced browser storage.
  *
  * @param key - The entry key.
  * @returns The entry.
  */
 async function get<T>(key: string): Promise<T | undefined> {
-    const localData: Record<string, T> = await chrome.storage.local.get(key);
+    const syncedData: Record<string, T> = await chrome.storage.sync.get(key);
 
-    if (Object.keys(localData).length === 0 || localData[key] === undefined) {
-        const syncedData: Record<string, T> = await chrome.storage.sync.get(key);
-        if (Object.keys(syncedData).length === 0 || syncedData[key] === undefined) {
-            return undefined;
-        }
-        return syncedData[key];
+    if (Object.keys(syncedData).length === 0 || syncedData[key] === undefined) {
+        return undefined;
     }
-    return localData[key];
+    return syncedData[key];
 }
 
 /**
- * Set an entry in the browser storage.
- * The entry will be set in both local
- * and synced storage.
+ * Set an entry in the synced browser storage.
+ *
  * @param key - The entry key.
  * @param value - The entry value.
  */
 async function set<T>(key: string, value: T) {
     const data: Record<string, T> = {};
     data[key] = value;
-    await chrome.storage.local.set(data);
     await chrome.storage.sync.set(data);
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above. -->

### Description

Attempts to fix bookmark bars getting merged when using the extension on multiple devices as mentioned in #194.
In particular, the extension will now access the synced storage only without the fallback to local storage.

@Kamiikaze please review and test, this may also solve the problem mentioned in #218 but I'm not sure.

### Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have created a feature (non-master) branch for my PR.
